### PR TITLE
Add vann:usageNote

### DIFF
--- a/0.3/ceasn2cassConcepts
+++ b/0.3/ceasn2cassConcepts
@@ -189,6 +189,9 @@
 		"vann:usageNote": {
 			"@id": "vann:usageNote",
 			"@container": "@language"
+		},
+		"ceasn:dateCreated": {
+			"@id": "schema:dateCreated"
 		}
 	}
 }

--- a/0.3/ceasn2cassConcepts
+++ b/0.3/ceasn2cassConcepts
@@ -185,6 +185,10 @@
 		},
 		"ceasn:source": {
 			"@id": "dc:source"
+		},
+		"vann:usageNote": {
+			"@id": "vann:usageNote",
+			"@container": "@language"
 		}
 	}
 }


### PR DESCRIPTION
To fix export error at https://github.com/cassproject/cass-editor/issues/514. Field was importing incorrectly so concept scheme will need to be reimported for fix to take effect.