### PR TITLE
Add several ceasn properties missing from export.

### DIFF
--- a/0.4/jsonld1.1/cass2ceasn.json
+++ b/0.4/jsonld1.1/cass2ceasn.json
@@ -165,6 +165,14 @@
 			"@id": "ceasn:derivedFrom",
 			"@type": "@id"
 		},
+		"ceasn:alignFrom": {
+			"@id": "ceasn:alignFrom",
+			"@type": "@id"
+		},
+		"ceasn:alignTo": {
+			"@id": "ceasn:alignTo",
+			"@type": "@id"
+		},
 		"ceasn:isPartOf": {
 			"@id": "ceasn:isPartOf",
 			"@type": "@id"

--- a/0.4/jsonld1.1/cass2ceasn.json
+++ b/0.4/jsonld1.1/cass2ceasn.json
@@ -33,8 +33,16 @@
 			"@id": "ceasn:listID",
 			"@type": "xsd:string"
 		},
+		"ceasn:altCodedNotation": {
+			"@id": "ceasn:altCodedNotation",
+			"@type": "xsd:string"
+		},
 		"ceasn:codedNotation": {
 			"@id": "ceasn:codedNotation",
+			"@type": "xsd:string"
+		},
+		"ceasn:localSubject": {
+			"@id": "ceasn:localSubject",
 			"@type": "xsd:string"
 		},
 		"ceasn:competencyLabel": {
@@ -44,7 +52,7 @@
 		"ceasn:competencyCategory": {
 			"@id": "ceasn:competencyCategory",
 			"@language": "en-US"
-		},
+		},		
 		"ceasn:name": {
 			"@id": "ceasn:name",
 			"@language": "en-US"
@@ -143,6 +151,14 @@
 		},
 		"ceasn:isChildOf": {
 			"@id": "ceasn:isChildOf",
+			"@type": "@id"
+		},
+		"ceasn:crossSubjectReference": {
+			"@id": "ceasn:crossSubjectReference",
+			"@type": "@id"
+		},
+		"ceasn:comprisedOf": {
+			"@id": "ceasn:comprisedOf",
 			"@type": "@id"
 		},
 		"ceasn:derivedFrom": {

--- a/0.4/jsonld1.1/cass2ceasn.json
+++ b/0.4/jsonld1.1/cass2ceasn.json
@@ -15,7 +15,7 @@
 		"loc": "http://www.loc.gov/loc.terms/",
 		"locr": "http://www.loc.gov/loc.terms/relators/",
 		"meta": "http://credreg.net/meta/terms/",
-		"publicationStatus": "http://credreg.net/ctdlasn/vocabs/publicationStatus/",
+		"publicationStatus": "https://credreg.net/ctdlasn/vocabs/publicationStatus/",
 		"skos": "http://www.w3.org/2004/02/skos/core#",
 		"vs": "https://www.w3.org/2003/06/sw-vocab-status/ns",
 		"xsd": "http://www.w3.org/2001/XMLSchema#",
@@ -43,7 +43,7 @@
 		},
 		"ceasn:localSubject": {
 			"@id": "ceasn:localSubject",
-			"@type": "xsd:string"
+			"@language": "en-US"
 		},
 		"ceasn:competencyLabel": {
 			"@id": "ceasn:competencyLabel",

--- a/0.4/jsonld1.1/cass2ceasnConcepts.json
+++ b/0.4/jsonld1.1/cass2ceasnConcepts.json
@@ -15,7 +15,7 @@
 		"loc": "http://www.loc.gov/loc.terms/",
 		"locr": "http://www.loc.gov/loc.terms/relators/",
 		"meta": "http://credreg.net/meta/terms/",
-		"publicationStatus": "http://credreg.net/ctdlasn/vocabs/publicationStatus/",
+		"publicationStatus": "https://credreg.net/ctdlasn/vocabs/publicationStatus/",
 		"skos": "http://www.w3.org/2004/02/skos/core#",
 		"vs": "https://www.w3.org/2003/06/sw-vocab-status/ns",
 		"xsd": "http://www.w3.org/2001/XMLSchema#",

--- a/0.4/jsonld1.1/cass2ceasnConcepts.json
+++ b/0.4/jsonld1.1/cass2ceasnConcepts.json
@@ -131,10 +131,6 @@
 			"@type": "@id",
 			"@container": "@list"
 		},
-		"skos:historyNote": {
-			"@id": "skos:historyNote",
-			"@language": "en-US"
-		},
 		"ceasn:license": {
 			"@id": "ceasn:license",
 			"@type": "@id"

--- a/0.4/jsonld1.1/cass2ceasncollection.json
+++ b/0.4/jsonld1.1/cass2ceasncollection.json
@@ -15,7 +15,7 @@
 		"loc": "http://www.loc.gov/loc.terms/",
 		"locr": "http://www.loc.gov/loc.terms/relators/",
 		"meta": "http://credreg.net/meta/terms/",
-		"publicationStatus": "http://credreg.net/ctdlasn/vocabs/publicationStatus/",
+		"publicationStatus": "https://credreg.net/ctdlasn/vocabs/publicationStatus/",
 		"skos": "http://www.w3.org/2004/02/skos/core#",
 		"vs": "https://www.w3.org/2003/06/sw-vocab-status/ns",
 		"xsd": "http://www.w3.org/2001/XMLSchema#",

--- a/0.4/jsonld1.1/ceasn2cassConcepts.json
+++ b/0.4/jsonld1.1/ceasn2cassConcepts.json
@@ -78,10 +78,6 @@
 			"@id": "dcterms:description",
 			"@container": "@language"
 		},
-		"skos:historyNote": {
-			"@id": "skos:historyNote",
-			"@container": "@language"
-		},
 		"ceasn:publisherName": {
 			"@id": "ceasn:publisherName",
 			"@container": "@language"

--- a/ctdlasn.json
+++ b/ctdlasn.json
@@ -12,7 +12,7 @@
 	"loc": "http://www.loc.gov/loc.terms/",
 	"locr": "http://www.loc.gov/loc.terms/relators/",
 	"meta": "http://credreg.net/meta/terms/",
-	"publicationStatus": "http://purl.org/ctdlasn/vocabs/publicationStatus/",
+	"publicationStatus": "https://purl.org/ctdlasn/vocabs/publicationStatus/",
 	"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 	"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
 	"schema": "http://schema.org/",


### PR DESCRIPTION
To align with data specifications for mapping to CTDL ASN:
Added comprisedOf, altCodedNotation, localSubject, crosssSubjectReference.
Removed historyNote