### PR TITLE
Support for importing ceasn:ProgressionModel

### DIFF
--- a/0.4/jsonld1.1/ceasn2cassConceptsTerms
+++ b/0.4/jsonld1.1/ceasn2cassConceptsTerms
@@ -1,6 +1,8 @@
 {
 	"skos:ConceptScheme": "cass:skos/ConceptScheme",
 	"skos:Concept": "cass:skos/Concept",
+	"ceasn:ProgressionModel": "cass:skos/ConceptScheme",
+	"ceasn:ProgressionLevel": "cass:skos/Concept",
 	"@owner": "ebac:@owner",
 	"@reader": "ebac:@reader",
 	"@signature": "ebac:@signature",


### PR DESCRIPTION
A ceasn ProgressionModel is imported as a ConceptScheme with subType of Progression, similar to how a Collection is imported as a Framework with subType of Collection.