### PR TITLE
skos:notation property needs to be string, not langstring

### DIFF
--- a/0.4/cass2ceasnConcepts
+++ b/0.4/cass2ceasnConcepts
@@ -95,7 +95,8 @@
 			"@type": "@id"
 		},
 		"skos:notation": {
-			"@id": "skos:notation"
+			"@id": "skos:notation",
+			"@type": "xsd:string"
 		},
 		"skos:note": {
 			"@id": "skos:note",

--- a/0.4/cass2ceasnProgressions
+++ b/0.4/cass2ceasnProgressions
@@ -63,7 +63,8 @@
 			"@container": "@list"
 		},
 		"skos:notation": {
-			"@id": "skos:notation"
+			"@id": "skos:notation",
+			"@type": "xsd:string"
 		},
 		"skos:note": {
 			"@id": "skos:note",

--- a/0.4/ceasn2cassConcepts
+++ b/0.4/ceasn2cassConcepts
@@ -96,7 +96,7 @@
 		},
 		"skos:notation": {
 			"@id": "skos:notation",
-			"@container": "@language"
+			"@type": "xsd:string"
 		},
 		"skos:note": {
 			"@id": "skos:note",

--- a/0.4/jsonld1.1/cass2ceasnConcepts.json
+++ b/0.4/jsonld1.1/cass2ceasnConcepts.json
@@ -43,7 +43,7 @@
 		},
 		"skos:notation": {
 			"@id": "skos:notation",
-			"@language": "en-us"
+			"@type": "xsd:string"
 		},
 		"skos:broader": {
 			"@id": "skos:broader",

--- a/0.4/jsonld1.1/cass2ceasnProgressions.json
+++ b/0.4/jsonld1.1/cass2ceasnProgressions.json
@@ -45,6 +45,10 @@
 			"@id": "skos:definition",
 			"@language": "en-us"
 		},
+		"skos:notation": {
+			"@id": "skos:notation",
+			"@type": "xsd:string"
+		},
 		"skos:narrower": {
 			"@id": "skos:narrower",
 			"@type": "@id",

--- a/0.4/jsonld1.1/ceasn2cassConcepts.json
+++ b/0.4/jsonld1.1/ceasn2cassConcepts.json
@@ -60,7 +60,7 @@
 		},
 		"skos:notation": {
 			"@id": "skos:notation",
-			"@container": "@language"
+			"@type": "xsd:string"
 		},
 		"skos:note": {
 			"@id": "skos:note",

--- a/ctdlasn.json
+++ b/ctdlasn.json
@@ -243,7 +243,7 @@
 	  "@container": "@language"
 	},
 	"skos:notation": {
-		"@container": "@language"
+		"@type": "xsd:string"
 	},
 	"skos:definition": {
 	  "@container": "@language"


### PR DESCRIPTION
Update to skos:notation property. Was set to langstring, but should be string