### PR TITLE
Ce 1306.3

### DIFF
--- a/0.4/cass2ceasnConcepts
+++ b/0.4/cass2ceasnConcepts
@@ -95,8 +95,7 @@
 			"@type": "@id"
 		},
 		"skos:notation": {
-			"@id": "skos:notation",
-			"@type": "xsd:string"
+			"@id": "skos:notation"
 		},
 		"skos:note": {
 			"@id": "skos:note",

--- a/0.4/cass2ceasnProgressions
+++ b/0.4/cass2ceasnProgressions
@@ -63,8 +63,7 @@
 			"@container": "@list"
 		},
 		"skos:notation": {
-			"@id": "skos:notation",
-			"@type": "xsd:string"
+			"@id": "skos:notation"
 		},
 		"skos:note": {
 			"@id": "skos:note",

--- a/0.4/jsonld1.1/cass2ceasnConcepts.json
+++ b/0.4/jsonld1.1/cass2ceasnConcepts.json
@@ -42,8 +42,7 @@
 			"@language": "en-us"
 		},
 		"skos:notation": {
-			"@id": "skos:notation",
-			"@type": "xsd:string"
+			"@id": "skos:notation"
 		},
 		"skos:broader": {
 			"@id": "skos:broader",

--- a/0.4/jsonld1.1/cass2ceasnProgressions.json
+++ b/0.4/jsonld1.1/cass2ceasnProgressions.json
@@ -46,8 +46,7 @@
 			"@language": "en-us"
 		},
 		"skos:notation": {
-			"@id": "skos:notation",
-			"@type": "xsd:string"
+			"@id": "skos:notation"
 		},
 		"skos:narrower": {
 			"@id": "skos:narrower",

--- a/0.4/jsonld1.1/ceasn2cassConcepts.json
+++ b/0.4/jsonld1.1/ceasn2cassConcepts.json
@@ -59,8 +59,7 @@
 			"@container": "@language"
 		},
 		"skos:notation": {
-			"@id": "skos:notation",
-			"@type": "xsd:string"
+			"@id": "skos:notation"
 		},
 		"skos:note": {
 			"@id": "skos:note",


### PR DESCRIPTION
Removed incorrect type on notation property to allow compaction. Should export as skos:notation.

https://github.com/cassproject/cass-editor/issues/1306
